### PR TITLE
refactor(editor): extract Monaco model utils + content store, simplify Editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ function App() {
           path={activePath || 'app/package.json'}
           getContent={getContent}
         />
+          <Editor activePath={activePath!} />
       </Panel>
     </PanelGroup>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,11 +41,7 @@ function App() {
       </Panel>
       <PanelResizeHandle className="border-l-[0.5px] border-l-neutral-600" />
       <Panel id="code-editor-panel" className="min-h-0" defaultSize={75}>
-        <Editor
-          path={activePath || 'app/package.json'}
-          getContent={getContent}
-        />
-          <Editor activePath={activePath!} />
+        <Editor activePath={activePath!} />
       </Panel>
     </PanelGroup>
   );

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,39 +1,15 @@
 import { useEffect, useRef } from 'react';
 import * as monaco from 'monaco-editor';
+import { getContent } from '../lib/contentStore';
+import { pathToUri, langFromExt } from '../lib/monaco/model-utils';
 
-const langFromExt = (path: string) => {
-  const ext = (path.split('.').pop() || '').toLowerCase();
-  switch (ext) {
-    case 'ts':
-    case 'tsx':
-      return 'typescript';
-    case 'js':
-    case 'jsx':
-      return 'javascript';
-    case 'json':
-      return 'json';
-    case 'md':
-      return 'markdown';
-    case 'css':
-      return 'css';
-    case 'html':
-      return 'html';
-  }
-};
-
-const Editor = ({
-  path,
-  getContent,
-}: {
-  path: string;
-  getContent: (p: string) => string;
-}) => {
+const Editor = ({ activePath }: { activePath: string }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
 
   useEffect(() => {
     const container = containerRef.current;
-    if (!container || !path) return;
+    if (!container || !activePath) return;
 
     // if no editor ref, create new
     if (!editorRef.current) {
@@ -54,10 +30,10 @@ const Editor = ({
     }
 
     // set up language model when filepath/content changes
-    const uri = monaco.Uri.parse(`inmem:/${encodeURI(path)}`);
+    const uri = pathToUri(activePath);
     const model = monaco.editor.createModel(
-      getContent(path),
-      langFromExt(path),
+      getContent(activePath),
+      langFromExt(activePath),
       uri,
     );
     editorRef.current.setModel(model);
@@ -69,7 +45,7 @@ const Editor = ({
         editorRef.current = null;
       }
     };
-  }, [path, getContent]);
+  }, [activePath]);
 
   return (
     <div

--- a/src/lib/contentStore.ts
+++ b/src/lib/contentStore.ts
@@ -1,0 +1,9 @@
+import files from '../data/reactTutorialFiles';
+import normalizePath from '../utils/normalizePath';
+
+const byPath = new Map<string, string>();
+for (const f of files) {
+  byPath.set(normalizePath(f.path), (f.content ?? '').replace(/^\n/, ''));
+}
+
+export const getContent = (p: string) => byPath.get(normalizePath(p)) ?? '';

--- a/src/lib/monaco/model-utils.ts
+++ b/src/lib/monaco/model-utils.ts
@@ -1,0 +1,37 @@
+import * as monaco from 'monaco-editor';
+import normalizePath from '../../utils/normalizePath';
+
+export const langFromExt = (path: string) => {
+  const ext = (path.split('.').pop() || '').toLowerCase();
+  switch (ext) {
+    case 'ts':
+    case 'tsx':
+      return 'typescript';
+    case 'js':
+    case 'jsx':
+      return 'javascript';
+    case 'json':
+      return 'json';
+    case 'md':
+      return 'markdown';
+    case 'css':
+      return 'css';
+    case 'html':
+      return 'html';
+  }
+};
+
+export const pathToUri = (path: string) =>
+  monaco.Uri.parse(`inmem:/${encodeURI(normalizePath(path))}`);
+
+export const getOrCreateModel = (
+  path: string,
+  getContent: (p: string) => string,
+) => {
+  const uri = pathToUri(path);
+  let model = monaco.editor.getModel(uri);
+  if (!model) {
+    model = monaco.editor.createModel(getContent(path), langFromExt(path), uri);
+  }
+  return model;
+};


### PR DESCRIPTION
**What & Why**
Moves editor helpers out of the component so the Editor stays lean and reusable. Adds a tiny content store for seeded file content and future save/restore.

**Changes**

- `lib/monaco/model-utils.ts`: `pathToUri`, `langFromExt`, `getOrCreateModel`
- `lib/contentStore.ts`: `getContent(path)` seeded from demo files
- `components/Editor.tsx`: imports the above, removes inline helpers
- `App.tsx`: update props passed to Editor component

**Test Plan**

- [ ] Open several files -> correct content appears each time
- [ ] Language-specific highlighting as expected (mode from `langFromExt`
- [ ] Switch between files quickly -> editor swaps models without flicker

**Risk / Rollback**
Low. Pure refactor, revert `Editor.tsx` to prior helpers if needed
