### PR TITLE
feat(editor): expose tabpanel linked to active tab

### DIFF
--- a/src/__tests__/editor.a11y.test.tsx
+++ b/src/__tests__/editor.a11y.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { Editor } from '../components';
+
+describe('Editor tabpanel a11y', () => {
+  it('links tabpanel to active tab via aria-labelledby', () => {
+    const { rerender } = render(<Editor activePath="/foo.ts" />);
+    const panel = screen.getByRole('tabpanel');
+
+    expect(panel).toHaveAttribute('id', 'editor-panel');
+    expect(panel.getAttribute('aria-labelledby')).toMatch(/^tab-/);
+
+    rerender(<Editor activePath="bar.ts" />);
+    expect(panel.getAttribute('aria-labelledby')).toContain('bar-ts');
+  });
+});

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import * as monaco from 'monaco-editor';
 import { getContent } from '../lib/contentStore';
 import { pathToUri, langFromExt } from '../lib/monaco/model-utils';
+import { tabIdFromPath } from '../utils/ids';
 
 const Editor = ({ activePath }: { activePath: string }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -21,7 +22,9 @@ const Editor = ({ activePath }: { activePath: string }) => {
         theme: 'vs-dark',
 
         renderValidationDecorations: 'off',
-        lightbulb: { enabled: monaco.editor.ShowLightbulbIconMode.Off },
+        lightbulb: {
+          enabled: (monaco as any).editor?.ShowLightbulbIconMode?.Off,
+        },
         quickSuggestions: { other: false, comments: false, strings: false },
         suggestOnTriggerCharacters: false,
         wordBasedSuggestions: 'off',
@@ -49,7 +52,9 @@ const Editor = ({ activePath }: { activePath: string }) => {
 
   return (
     <div
-      role="text editor"
+      role="tabpanel"
+      id="editor-panel"
+      aria-labelledby={tabIdFromPath(activePath)}
       ref={containerRef}
       className="h-full w-full min-h-0"
     />

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -3,9 +3,9 @@ import { useFileState, useFileActions } from '../state/ActiveFileProvider';
 import FileIcon from './FileIcon';
 import CloseIcon from './CloseIcon';
 import { cn } from '../utils/cn';
+import { tabIdFromPath } from '../utils/ids';
 
 const fileName = (p: string) => p.split('/').pop() || p;
-const tabIdFromPath = (p: string) => 'tab-' + p.replace(/[^a-zA-Z0-9_-]/g, '-');
 
 type TabProps = {
   path: string;

--- a/src/test/mocks/monaco-editor.ts
+++ b/src/test/mocks/monaco-editor.ts
@@ -1,0 +1,26 @@
+export const editor = {
+  ShowLightbulbIconMode: { Off: 0 } as any,
+  create: () => ({
+    setModel: () => {},
+    dispose: () => {},
+    onDidChangeModelContent: () => ({ dispose: () => {} }),
+    layout: () => {},
+  }),
+  createModel: () => ({ dispose: () => {} }),
+  getModels: () => [],
+  getModel: () => null,
+};
+
+export const Uri = {
+  file: (p: string) => ({
+    path: p,
+    toString: () => `file://${p}`,
+  }),
+  parse: (s: string) => ({
+    path: s.replace(/^file:\/\//, ''),
+    toString: () => s,
+  }),
+};
+
+const monaco = { editor, Uri };
+export default monaco;

--- a/src/utils/ids.ts
+++ b/src/utils/ids.ts
@@ -1,0 +1,2 @@
+export const tabIdFromPath = (p: string) =>
+  'tab-' + p.replace(/[^a-zA-Z0-9_-]/g, '-');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,11 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      'monaco-editor': '/src/test/mocks/monaco-editor.ts',
+    },
+  },
   test: {
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     environment: 'jsdom',


### PR DESCRIPTION
**What & Why**
Link active tab to editor tabpanel for a11y, add test to verify functionality and mock editor.

**Changes**

- Set correct `role`, `id`, and `aria-labelledby` on editor
- Test to ensure correct id switching on tab switch
- Mock `monaco-editor` for tests
- Move `tabIdFromPath` to `utils` to keep things tidy

**Test Plan**

- [ ] Switch tab, check `aria-labelledby` in devtools
- [ ] Run `pnpm test` and see that tests pass

**Risk / Rollback**
Low / revert Editor if needed
