### PR TITLE
perf(editor): add performance marks; test(e2e) perf budget, smoke test

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -3,6 +3,7 @@ import * as monaco from 'monaco-editor';
 import { getContent } from '../lib/contentStore';
 import { pathToUri, langFromExt } from '../lib/monaco/model-utils';
 import { tabIdFromPath } from '../utils/ids';
+import { perf } from '../utils/perf';
 
 const Editor = ({ activePath }: { activePath: string }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -14,6 +15,7 @@ const Editor = ({ activePath }: { activePath: string }) => {
 
     // if no editor ref, create new
     if (!editorRef.current) {
+      perf.mark('editor:create:start');
       editorRef.current = monaco.editor.create(container, {
         readOnly: true,
         automaticLayout: true,
@@ -30,6 +32,9 @@ const Editor = ({ activePath }: { activePath: string }) => {
         wordBasedSuggestions: 'off',
         parameterHints: { enabled: false },
       });
+
+      perf.mark('editor:create:end');
+      perf.measure('editor:create', 'editor:create:start', 'editor:create:end');
     }
 
     // set up language model when filepath/content changes
@@ -39,7 +44,15 @@ const Editor = ({ activePath }: { activePath: string }) => {
       langFromExt(activePath),
       uri,
     );
+    perf.mark('editor:model:set:start');
     editorRef.current.setModel(model);
+
+    perf.mark('editor:model:set:end');
+    perf.measure(
+      'editor:model:set',
+      'editor:model:set:start',
+      'editor:model:set:end',
+    );
 
     return () => {
       model.dispose();

--- a/src/utils/perf.ts
+++ b/src/utils/perf.ts
@@ -1,0 +1,16 @@
+const enabled = import.meta.env.MODE !== 'production';
+export const perf = {
+  mark(name: string) {
+    if (enabled && 'mark' in performance) performance.mark(name);
+  },
+  measure(name: string, start: string, end?: string) {
+    if (enabled && 'measure' in performance)
+      performance.measure(name, start, end);
+  },
+  entries(name?: string) {
+    if (enabled && 'entries' in performance)
+      return name
+        ? performance.getEntriesByName(name)
+        : performance.getEntriesByType('measure');
+  },
+};

--- a/tests/e2e/perf.spec.ts
+++ b/tests/e2e/perf.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test('perf budgets: editor create/model set', async ({ page }) => {
+  await page.goto('/');
+  // open a second file via the tree to trigger setModel on a new file
+  await page.getByRole('treeitem', { name: 'index.html' }).click();
+
+  const metrics = await page.evaluate(() => {
+    const first = (n: string) =>
+      performance.getEntriesByName(n)[0]?.duration ?? null;
+    const nav = performance.getEntriesByType('navigation')[0] as
+      | PerformanceNavigationTiming
+      | undefined;
+    return {
+      editorCreateMs: first('editor:create'),
+      modelSetMs: first('editor:model:set'),
+      domContentLoadedMs: nav?.domContentLoadedEventEnd ?? null,
+    };
+  });
+
+  test.info().attach('perf.json', {
+    body: JSON.stringify(metrics, null, 2),
+    contentType: 'application/json',
+  });
+
+  // Generous budgets; tighten later once numbers stabilize
+  if (metrics.editorCreateMs != null)
+    expect(metrics.editorCreateMs).toBeLessThan(350);
+  if (metrics.modelSetMs != null) expect(metrics.modelSetMs).toBeLessThan(250);
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('boots + shows main landmarks', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('tablist')).toBeVisible();
+});


### PR DESCRIPTION
**What & Why**
Add `performance.mark/measure` around Monaco `create` and `setModel` to measure performance, identify issues

**Changes**

- Add `performance.mark/measure` around Monaco
- Playwright test to capture metrics & enforce loose budgets, attach `perf.json` artifact
- perf helper no-ops in production; no runtime cost in prod
- add smoke test

**Test Plan**

- [ ] Run `pnpm e2e`; smoke test and perf test should pass

**Risk / Rollback**
Low / revert `Editor.tsx` if needed
