### PR TITLE
feat(tabs): roving focus + scroll-into-view; Provider seeding; RTL tests

### DIFF
--- a/src/__tests__/tabs.a11y.test.tsx
+++ b/src/__tests__/tabs.a11y.test.tsx
@@ -1,33 +1,27 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
-import { Tab } from '../components/Tabs';
-import { useState } from 'react';
+import Tabs from '../components/Tabs';
+// import { useState } from 'react';
+import ActiveFileProvider from '../state/ActiveFileProvider';
 
 describe('Tabs a11y semantics', () => {
-  const files = ['/foo.ts', '/bar.ts', '/baz/ts'];
+  function TabsHarness({
+    open = ['app/README.md', 'app/index.html', 'app/vite.config.ts'],
+    active = 'app/README.md',
+  }: {
+    open?: string[];
+    active?: string;
+  }) {
+    return (
+      <ActiveFileProvider initial={{ openPaths: open, activePath: active }}>
+        <Tabs />
+      </ActiveFileProvider>
+    );
+  }
 
   it('marks only the active tab as tabbable and selected', () => {
-    const onSelect = vi.fn();
-    const onClose = vi.fn();
-
-    render(
-      <div role="tablist" aria-label="Open files">
-        <Tab path={files[0]} active onSelect={onSelect} onClose={onClose} />
-        <Tab
-          path={files[1]}
-          active={false}
-          onSelect={onSelect}
-          onClose={onClose}
-        />
-        <Tab
-          path={files[2]}
-          active={false}
-          onSelect={onSelect}
-          onClose={onClose}
-        />
-      </div>,
-    );
+    render(<TabsHarness />);
 
     const tabs = screen.getAllByRole('tab');
     expect(tabs).toHaveLength(3);
@@ -35,64 +29,38 @@ describe('Tabs a11y semantics', () => {
     expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
     expect(tabs[0]).toHaveAttribute('tabIndex', '0');
     expect(tabs[0]).toHaveAttribute('aria-controls', 'editor-panel');
-    expect(tabs[0]).toHaveAttribute('id', 'tab--foo-ts');
 
     expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
     expect(tabs[1]).toHaveAttribute('tabIndex', '-1');
   });
 
   it('activates on Enter/Space', async () => {
+    render(<TabsHarness />);
     const u = user.setup();
-    const onClose = vi.fn();
 
-    function StateHarness() {
-      const [active, setActive] = useState('');
-      return (
-        <div role="tablist" aria-label="Open files">
-          <Tab
-            path="/foo.ts"
-            active={active === '/foo.ts'}
-            onSelect={setActive}
-            onClose={onClose}
-          />
-          <Tab
-            path="/bar.ts"
-            active={active === '/bar.ts'}
-            onSelect={setActive}
-            onClose={onClose}
-          />
-        </div>
-      );
-    }
+    const viteConfig = screen.getByRole('tab', { name: 'app/vite.config.ts' });
+    const indexFile = screen.getByRole('tab', { name: 'app/index.html' });
 
-    render(<StateHarness />);
-
-    const foo = screen.getByRole('tab', { name: /foo\.ts/i });
-    const bar = screen.getByRole('tab', { name: /bar\.ts/i });
-
-    foo.focus();
-    expect(foo).toHaveAttribute('aria-selected', 'false');
-    expect(foo).toHaveAttribute('tabindex', '-1');
+    viteConfig.focus();
+    expect(viteConfig).toHaveAttribute('aria-selected', 'false');
+    expect(viteConfig).toHaveAttribute('tabindex', '-1');
 
     await u.keyboard('{Enter}');
-    expect(screen.getByRole('tab', { name: /foo\.ts/i })).toHaveAttribute(
-      'aria-selected',
-      'true',
-    );
-    expect(screen.getByRole('tab', { name: /foo\.ts/i })).toHaveAttribute(
-      'tabindex',
-      '0',
-    );
+    expect(
+      screen.getByRole('tab', { name: 'app/vite.config.ts' }),
+    ).toHaveAttribute('aria-selected', 'true');
+    expect(
+      screen.getByRole('tab', { name: 'app/vite.config.ts' }),
+    ).toHaveAttribute('tabindex', '0');
 
-    bar.focus();
+    indexFile.focus();
     await u.keyboard(' ');
-    expect(screen.getByRole('tab', { name: /bar\.ts/i })).toHaveAttribute(
+    expect(screen.getByRole('tab', { name: 'app/index.html' })).toHaveAttribute(
       'aria-selected',
       'true',
     );
-    expect(screen.getByRole('tab', { name: /foo\.ts/i })).toHaveAttribute(
-      'aria-selected',
-      'false',
-    );
+    expect(
+      screen.getByRole('tab', { name: 'app/vite.config.ts' }),
+    ).toHaveAttribute('aria-selected', 'false');
   });
 });

--- a/src/__tests__/tabs.test.tsx
+++ b/src/__tests__/tabs.test.tsx
@@ -1,0 +1,134 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import Tabs from '../components/Tabs';
+import ActiveFileProvider from '../state/ActiveFileProvider';
+import { nextFrame } from '../test/utils';
+import { getAllTabs, oneTabbable } from '../test/utils';
+
+function TabsHarness({
+  open = [
+    'app/README.md',
+    'app/index.html',
+    'app/vite.config.ts',
+    'app/package.json',
+    'app/src/main.tsx',
+    'app/src/App.tsx',
+    'app/src/styles/global.css',
+    'app/src/components/Button.tsx',
+  ],
+  active = 'app/README.md',
+}: {
+  open?: string[];
+  active?: string;
+}) {
+  return (
+    <ActiveFileProvider initial={{ openPaths: open, activePath: active }}>
+      <Tabs />
+    </ActiveFileProvider>
+  );
+}
+
+const u = user.setup();
+const k = async (key: string) => {
+  await u.keyboard(key);
+  await nextFrame();
+};
+
+describe('Tabs - roving and activation', () => {
+  test('exactly one tabbable tab, roves with arrows', async () => {
+    render(<TabsHarness />);
+
+    expect(oneTabbable()).toHaveLength(1);
+
+    (oneTabbable()[0] as HTMLElement).focus();
+    expect(oneTabbable()[0]).toHaveFocus();
+
+    // ArrowRight moves focus only (not selection)
+    await k('{ArrowRight}');
+    const tabsAfter = getAllTabs();
+    expect(oneTabbable()).toHaveLength(1);
+    expect(
+      tabsAfter.some((t) => t.getAttribute('aria-selected') === 'true'),
+    ).toBe(true);
+    // Focus is on a tab, but aria-selected stays with the previously active one
+    const focused = document.activeElement as HTMLElement;
+    expect(focused).toHaveAttribute('role', 'tab');
+  });
+
+  test('Home/End jump to first/last', async () => {
+    render(<TabsHarness />);
+    (oneTabbable()[0] as HTMLElement).focus();
+
+    await k('{End}');
+    const all = getAllTabs();
+    expect(all.at(-1)).toHaveFocus();
+
+    await k('{Home}');
+    expect(getAllTabs()[0]).toHaveFocus();
+  });
+
+  test('Enter activates the focused tab (selection flips), focus remains on that tab', async () => {
+    render(<TabsHarness />);
+    (oneTabbable()[0] as HTMLElement).focus();
+
+    await k('{ArrowRight}'); // move focus to a different tab
+    const focused = document.activeElement as HTMLElement;
+    expect(focused).toHaveAttribute('role', 'tab');
+    expect(focused).toHaveAttribute('aria-selected', 'false');
+
+    await k('{Enter}'); // activate
+    expect(focused).toHaveAttribute('aria-selected', 'true');
+    expect(focused).toHaveFocus(); // focus stays put
+  });
+
+  test('Delete closes the focused tab and moves focus to its neighbor', async () => {
+    render(<TabsHarness />);
+    (oneTabbable()[0] as HTMLElement).focus();
+
+    const tabs0 = getAllTabs();
+    await k('{ArrowRight}');
+    const mid = document.activeElement as HTMLElement;
+    const beforeIdx = getAllTabs().findIndex((el) => el === mid);
+
+    await k('{Delete}');
+    const tabs1 = getAllTabs();
+    // One fewer tab
+    expect(tabs1.length).toBe(tabs0.length - 1);
+    // Focus moved to neighbor (same index now points at the next one)
+    const neighbor = tabs1[Math.min(beforeIdx, tabs1.length - 1)];
+    expect(neighbor).toHaveFocus();
+  });
+
+  test('Ctrl/Cmd+W closes the focused tab', async () => {
+    render(<TabsHarness />);
+    const u = user.setup();
+    (oneTabbable()[0] as HTMLElement).focus();
+
+    const tabs0 = getAllTabs();
+    const isMac = navigator.platform.includes('Mac');
+    await u.keyboard(isMac ? '{Meta>}{w}{/Meta}' : '{Control>}{w}{/Control}');
+    expect(getAllTabs().length).toBe(Math.max(0, tabs0.length - 1));
+  });
+
+  test('scrolls active tab into view when activePath changes', async () => {
+    render(<TabsHarness />);
+    const all = getAllTabs();
+
+    // spy on scrollIntoView for a far tab
+    const far = all.at(-1)! as HTMLElement;
+    const spy = vi
+      .spyOn(far, 'scrollIntoView' as any)
+      .mockImplementation(() => {});
+
+    // move focus to far tab then activate with Enter
+    far.focus();
+    await k('{Enter}');
+
+    // effect runs in rAF; give it a tick
+    await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    expect(spy).toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+});

--- a/src/components/FileTreeNode.tsx
+++ b/src/components/FileTreeNode.tsx
@@ -46,6 +46,7 @@ const FileTreeNode = ({
         className={cn(
           'flex w-full items-center gap-0.5 py-[1px] hover:cursor-pointer',
           isActive ? 'bg-neutral-600/50' : 'hover:bg-neutral-700/50',
+          isFocused && 'outline-2 outline-neutral-500/60',
         )}
         style={{ paddingLeft: `${depth / 2}rem` }}
         title={file.path}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,10 +1,15 @@
-import { afterEach, expect } from 'vitest';
+import { afterEach, expect, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 
 const matchers = (jestDomMatchers as any).default ?? jestDomMatchers;
 
 expect.extend(matchers);
+
+Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+  value: vi.fn(),
+  writable: true,
+});
 
 afterEach(() => {
   cleanup();

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -25,3 +25,9 @@ export const expectOneTabbable = () => {
 };
 export const getSelected = () =>
   getItems().filter((el) => el.getAttribute('aria-selected') === 'true');
+
+export const getTabs = () =>
+  screen.getByRole('tablist', { name: /open files/i });
+export const getAllTabs = () => within(getTabs()).getAllByRole('tab');
+export const oneTabbable = () =>
+  getAllTabs().filter((el) => (el as HTMLElement).tabIndex === 0);


### PR DESCRIPTION
**What & Why**
Improve keyboard/a11y for Tabs and make tests deterministic

**Changes**

- `State`: ActiveFileProvider now accepts an initial seed (activePath, openPaths, expandedPaths, treeFocusPath) for predictable startup in tests and demos. Paths normalized on write
- `Tabs`: Roving focus owned by tabs component, exactly 1 tabbable.
- Map based refs for stability under reorders
- Active tab auto scrolls into view (respects reduced motion)
- Tests: RTL harness + helpers, jsdom `scrollIntoView` polyfill

**Test Plan**

- [ ] Arrow keys wrap and don't activate
- [ ] Active tab scrolls into view when changed via app state


**Risk / Rollback**
Low, isolated to tabs and provider / revert commit 2 if needed
