### PR TITLE
feat(monaco): lifecycle improvements, resizeObserver, ErrorBoundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Breadcrumbs from './components/Breadcrumbs';
 import reactTutorialFiles from './data/reactTutorialFiles';
 import buildTree from './lib/buildTree';
 import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
+import { ErrorBoundary } from './components/ErrorBoundary';
 
 function App() {
   const { activePath, openPaths } = useFileState();
@@ -29,11 +30,13 @@ function App() {
         {activePath === null && openPaths.length === 0 ? (
           <EmptyEditor />
         ) : (
-          <div className="flex flex-col h-full w-full min-h-0">
-            <Tabs />
-            <Breadcrumbs path={activePath!} />
-            <Editor activePath={activePath!} />
-          </div>
+          <ErrorBoundary resetKey={activePath}>
+            <div className="flex flex-col h-full w-full min-h-0">
+              <Tabs />
+              <Breadcrumbs path={activePath!} />
+              <Editor activePath={activePath!} />
+            </div>
+          </ErrorBoundary>
         )}
       </Panel>
     </PanelGroup>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,53 @@
+import { Component, type ReactNode } from 'react';
+
+type Props = {
+  resetKey: string | null;
+  fallback?: ReactNode;
+  children: ReactNode;
+};
+type State = { hasError: boolean; error?: Error };
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: any) {
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.error('[ErrorBoundary]', error, info);
+    }
+  }
+
+  componentDidUpdate(prev: Props) {
+    if (this.props.resetKey !== prev.resetKey && this.state.hasError) {
+      this.setState({ hasError: false, error: undefined });
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback ?? (
+          <div className="p-4 text-sm">
+            <div className="font-semibold mb-1">Something went wrong.</div>
+            <pre className="whitespace-pre-wrap text-xs opacity-70">
+              {this.state.error?.message}
+            </pre>
+            <button
+              className="mt-3 rounded-2xl border px-3 py-1.5"
+              onClick={() =>
+                this.setState({ hasError: false, error: undefined })
+              }
+            >
+              Try again
+            </button>
+          </div>
+        )
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/hooks/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+export const useResizeObserver = (
+  el: HTMLElement | null,
+  onSize: (entry: ResizeObserverEntry) => void,
+) => {
+  useEffect(() => {
+    if (!el) return;
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const e of entries) onSize(e);
+    });
+    resizeObserver.observe(el);
+    return () => resizeObserver.disconnect();
+  }, [el, onSize]);
+};


### PR DESCRIPTION
**What & Why**
Hardens the editor surface and removes jank:
- one-model-per-file with a ref-counted registry for no leaks, fast swaps, future multipane support
- onResizeObserver hook for smoother resizes
- Editor only rebinds the model on path changes
- ErrorBoundary around the editor area with a reset on file change

**Changes**

- segment-encoded uri for better path handling (spaces, unexpected characters)
- guard with `model.onWillDispose` to keep registry consistent
- `useResizeObserver` to call editor.layout() on host size changes
- remove `automaticLayout: true`; rely on observer hook
- Add ErrorBoundary component around editor, user can recover with try again button or by switching files

**Test Plan**

- [ ] Switch quickly between multiple files, should see fast loads
- [ ] resize window, resize panels, editor layout updates instantly (no flickering minimap)
- [ ] open/close tabs, confirm models are created/reused/disposed appropriately
- [ ] Throw an error in editor based on filetype, ErrorBoundary appears when that filetype is opened

**Risk / Rollback**
Low / revert `Editor.tsx` if needed
