### PR TITLE
feat(persistence): Global save shortcut + dirty tracking + Saved toast (plus small test fixes)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,45 +1,71 @@
-import { useFileState } from './state/ActiveFileProvider';
+import { useFileState, useFileActions } from './state/ActiveFileProvider';
 import { Editor, EmptyEditor, FileTree, Tabs } from './components';
 import Breadcrumbs from './components/Breadcrumbs';
 import reactTutorialFiles from './data/reactTutorialFiles';
 import buildTree from './lib/buildTree';
 import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import useSaveShortcut from './hooks/useSaveShortcut';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import SavedToast from './components/SavedToast';
 
 function App() {
   const { activePath, openPaths } = useFileState();
+  const { saveFile } = useFileActions();
+  const [saved, setSaved] = useState(false);
+  const hideTimer = useRef<number | null>(null);
+
+  const onSave = useCallback(() => {
+    if (!activePath) return;
+    saveFile(activePath);
+    setSaved(true);
+    if (hideTimer.current) window.clearTimeout(hideTimer.current);
+    hideTimer.current = window.setTimeout(() => setSaved(false), 2000);
+  }, [activePath, saveFile]);
+
+  useEffect(
+    () => () => {
+      if (hideTimer.current) window.clearTimeout(hideTimer.current);
+    },
+    [],
+  );
+
+  useSaveShortcut(Boolean(activePath), onSave);
 
   const rootNode = buildTree(reactTutorialFiles.files);
 
   return (
-    <PanelGroup
-      id="file-viewer-group"
-      direction="horizontal"
-      className="h-full"
-    >
-      <Panel
-        id="file-tree-panel"
-        className="min-h-0"
-        defaultSize={25}
-        minSize={10}
+    <>
+      <PanelGroup
+        id="file-viewer-group"
+        direction="horizontal"
+        className="h-full"
       >
-        <FileTree projectName={reactTutorialFiles.name} rootNode={rootNode} />
-      </Panel>
-      <PanelResizeHandle className="border-l-[0.5px] border-l-neutral-600" />
-      <Panel id="code-editor-panel" className="min-h-0" defaultSize={75}>
-        {activePath === null && openPaths.length === 0 ? (
-          <EmptyEditor />
-        ) : (
-          <ErrorBoundary resetKey={activePath}>
-            <div className="flex flex-col h-full w-full min-h-0">
-              <Tabs />
-              <Breadcrumbs path={activePath!} />
-              <Editor activePath={activePath!} />
-            </div>
-          </ErrorBoundary>
-        )}
-      </Panel>
-    </PanelGroup>
+        <Panel
+          id="file-tree-panel"
+          className="min-h-0"
+          defaultSize={25}
+          minSize={10}
+        >
+          <FileTree projectName={reactTutorialFiles.name} rootNode={rootNode} />
+        </Panel>
+        <PanelResizeHandle className="border-l-[0.5px] border-l-neutral-600" />
+        <Panel id="code-editor-panel" className="min-h-0" defaultSize={75}>
+          {activePath === null && openPaths.length === 0 ? (
+            <EmptyEditor />
+          ) : (
+            <ErrorBoundary resetKey={activePath}>
+              <div className="flex flex-col h-full w-full min-h-0">
+                <Tabs />
+                <Breadcrumbs path={activePath!} />
+                <Editor activePath={activePath!} />
+              </div>
+            </ErrorBoundary>
+          )}
+        </Panel>
+      </PanelGroup>
+      <SavedToast show={saved} />
+    </>
   );
 }
 

--- a/src/__tests__/editor.a11y.test.tsx
+++ b/src/__tests__/editor.a11y.test.tsx
@@ -1,17 +1,26 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import ActiveFileProvider from '../state/ActiveFileProvider';
 
 import { Editor } from '../components';
 
 describe('Editor tabpanel a11y', () => {
   it('links tabpanel to active tab via aria-labelledby', () => {
-    const { rerender } = render(<Editor activePath="/foo.ts" />);
+    const { rerender } = render(
+      <ActiveFileProvider>
+        <Editor activePath="/foo.ts" />
+      </ActiveFileProvider>,
+    );
     const panel = screen.getByRole('tabpanel');
 
     expect(panel).toHaveAttribute('id', 'editor-panel');
     expect(panel.getAttribute('aria-labelledby')).toMatch(/^tab-/);
 
-    rerender(<Editor activePath="bar.ts" />);
+    rerender(
+      <ActiveFileProvider>
+        <Editor activePath="bar.ts" />
+      </ActiveFileProvider>,
+    );
     expect(panel.getAttribute('aria-labelledby')).toContain('bar-ts');
   });
 });

--- a/src/__tests__/hello.test.tsx
+++ b/src/__tests__/hello.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
 
 function HelloButton() {
-  return <button onClick={() => alert('clicked')}>Hello</button>;
+  return <button onClick={() => console.log('clicked')}>Hello</button>;
 }
 
 describe('hello test', () => {

--- a/src/__tests__/useSaveShortcut.test.tsx
+++ b/src/__tests__/useSaveShortcut.test.tsx
@@ -1,0 +1,55 @@
+// src/hooks/useSaveShortcut.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import useSaveShortcut from '../hooks/useSaveShortcut';
+
+function Harness({
+  enabled,
+  onSave,
+}: {
+  enabled: boolean;
+  onSave: () => void;
+}) {
+  useSaveShortcut(enabled, onSave);
+  return <div>ok</div>;
+}
+
+const fireKey = (init: KeyboardEventInit) => {
+  const ev = new KeyboardEvent('keydown', { cancelable: true, ...init });
+  const ok = window.dispatchEvent(ev);
+  return { ev, ok };
+};
+
+describe('useSaveShortcut', () => {
+  beforeEach(() => {
+    // ensure focus not in an input/textarea
+    (document.activeElement as HTMLElement | null)?.blur?.();
+  });
+
+  it('calls onSave for Cmd/Ctrl+S and prevents default', () => {
+    const spy = vi.fn();
+    render(<Harness enabled={true} onSave={spy} />);
+
+    const { ev } = fireKey({ key: 's', metaKey: true });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(ev.defaultPrevented).toBe(true);
+
+    const { ev: ev2 } = fireKey({ key: 'S', ctrlKey: true });
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(ev2.defaultPrevented).toBe(true);
+  });
+
+  it('does nothing when disabled', () => {
+    const spy = vi.fn();
+    render(<Harness enabled={false} onSave={spy} />);
+    fireKey({ key: 's', metaKey: true });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('ignores repeats', () => {
+    const spy = vi.fn();
+    render(<Harness enabled={true} onSave={spy} />);
+    fireKey({ key: 's', metaKey: true, repeat: true });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/SavedToast.tsx
+++ b/src/components/SavedToast.tsx
@@ -1,0 +1,13 @@
+import { createPortal } from 'react-dom';
+
+export default function SavedToast({ show }: { show: boolean }) {
+  if (!show || typeof document === 'undefined') return null;
+  return createPortal(
+    <div className="fixed bottom-4 right-4 z-50 pointer-events-none">
+      <div className="rounded-lg px-3 py-2 text-sm text-white bg-emerald-600 shadow-xl">
+        Saved
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/hooks/useSaveShortcut.ts
+++ b/src/hooks/useSaveShortcut.ts
@@ -1,0 +1,44 @@
+import { useEffect, useCallback } from 'react';
+
+const useSaveShortcut = (enabled: boolean, onSave: () => void) => {
+  const handler = useCallback(
+    (e: KeyboardEvent) => {
+      const isSaveCombo =
+        (e.metaKey || e.ctrlKey) &&
+        (e.code === 'KeyS' || e.key.toLowerCase() === 's');
+      if (!isSaveCombo) return;
+
+      e.preventDefault();
+      if (e.repeat) {
+        return;
+      }
+      1;
+      const el = document.activeElement as HTMLElement | null;
+      const isInMonaco = !!el?.closest?.('.monaco-editor, .monaco-diff-editor');
+      const isNativeTextField =
+        !!el &&
+        (el.tagName === 'INPUT' ||
+          el.tagName === 'TEXTAREA' ||
+          el.isContentEditable ||
+          el.getAttribute('role') === 'textbox');
+
+      if (isNativeTextField && !isInMonaco) {
+        return;
+      }
+
+      onSave();
+    },
+    [onSave],
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !enabled) return;
+    window.addEventListener('keydown', handler, { capture: true });
+
+    return () => {
+      window.removeEventListener('keydown', handler, { capture: true });
+    };
+  }, [enabled, handler]);
+};
+
+export default useSaveShortcut;

--- a/src/lib/contentStore.ts
+++ b/src/lib/contentStore.ts
@@ -2,8 +2,13 @@ import files from '../data/reactTutorialFiles';
 import normalizePath from '../utils/normalizePath';
 
 const byPath = new Map<string, string>();
+
 for (const f of files.files) {
-  byPath.set(normalizePath(f.path), (f.content ?? '').replace(/^\n/, ''));
+  byPath.set(normalizePath(f.path), f.content ?? '');
 }
 
 export const getContent = (p: string) => byPath.get(normalizePath(p)) ?? '';
+
+export const setContent = (p: string, text: string) => {
+  byPath.set(normalizePath(p), text);
+};

--- a/src/lib/monaco/model-utils.ts
+++ b/src/lib/monaco/model-utils.ts
@@ -61,10 +61,12 @@ export const acquireModel = (
     registry.set(key, entry);
 
     model.onWillDispose(() => {
-      if (
-        process.env.NODE_DEV !== 'production' &&
-        (registry.get(key)?.ref ?? 0) > 0
-      ) {
+      const isDev =
+        (typeof import.meta !== 'undefined' && (import.meta as any).env?.DEV) ||
+        (typeof process !== 'undefined' &&
+          process.env?.NODE_ENV !== 'production');
+      if (isDev && (registry.get(key)?.ref ?? 0) > 0) {
+        // eslint-disable-next-line no-console
         console.warn('[monaco] model disposed with positive refcount', key);
       }
       registry.delete(key);


### PR DESCRIPTION
**What & Why**
Adds a small, reliable save UX and hardens editor internals

**Changes**

- Global Cmd/Ctrl-S 
- Saved toast via portal
- Dirty tracking derived from `model.getValue() !== getContent(path)`
- `saveFile(path)` persists to `contentStore.setContent`
- Dev guard in `model-utils` gets rid of process error in browser console

**Test Plan**

- [ ] Hook unit test asserts `preventDefault` + `onSave` called
- [ ] Editor a11y test passes with provider

**Risk / Rollback**
Low - `readOnly` is false so users can now edit files; revert to true to roll back.
