### PR TITLE
feat(files): inline file creation flow, open on create

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,6 @@
 import { useFileState, useFileActions } from './state/ActiveFileProvider';
 import { Editor, EmptyEditor, FileTree, Tabs } from './components';
 import Breadcrumbs from './components/Breadcrumbs';
-import reactTutorialFiles from './data/reactTutorialFiles';
-import buildTree from './lib/buildTree';
 import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import useSaveShortcut from './hooks/useSaveShortcut';
@@ -32,8 +30,6 @@ function App() {
 
   useSaveShortcut(Boolean(activePath), onSave);
 
-  const rootNode = buildTree(reactTutorialFiles.files);
-
   return (
     <>
       <PanelGroup
@@ -47,7 +43,7 @@ function App() {
           defaultSize={25}
           minSize={10}
         >
-          <FileTree projectName={reactTutorialFiles.name} rootNode={rootNode} />
+          <FileTree />
         </Panel>
         <PanelResizeHandle className="border-l-[0.5px] border-l-neutral-600" />
         <Panel id="code-editor-panel" className="min-h-0" defaultSize={75}>

--- a/src/__tests__/ActiveFileProvider.newFile.test.tsx
+++ b/src/__tests__/ActiveFileProvider.newFile.test.tsx
@@ -1,0 +1,45 @@
+// src/__tests__/ActiveFileProvider.newFile.test.tsx
+import { describe, it, expect } from 'vitest';
+import { useEffect } from 'react';
+import { render, screen } from '@testing-library/react';
+import ActiveFileProvider, {
+  useFileActions,
+  useFileState,
+} from '../state/ActiveFileProvider';
+import { getContent, hasPath } from '../lib/contentStore';
+
+function DriveNewFile({ dir, name }: { dir: string; name: string }) {
+  const { beginNewFileAt, setNewFileName, confirmNewFile } = useFileActions();
+  const { activePath, openPaths } = useFileState();
+
+  useEffect(() => {
+    beginNewFileAt(dir);
+    setNewFileName(name);
+    confirmNewFile();
+  }, [beginNewFileAt, setNewFileName, confirmNewFile, dir, name]);
+
+  return (
+    <div>
+      <div data-testid="active">{activePath ?? ''}</div>
+      <div data-testid="open">{openPaths.join('|')}</div>
+    </div>
+  );
+}
+
+describe('ActiveFileProvider new file', () => {
+  it('creates, opens, and focuses a new empty file', () => {
+    render(
+      <ActiveFileProvider>
+        <DriveNewFile dir="app" name="newfile.test.md" />
+      </ActiveFileProvider>,
+    );
+
+    const expected = 'app/newfile.test.md';
+
+    expect(hasPath(expected)).toBe(true);
+    expect(getContent(expected)).toBe(''); // committed empty content
+
+    expect(screen.getByTestId('active').textContent).toBe(expected);
+    expect(screen.getByTestId('open').textContent).toContain(expected);
+  });
+});

--- a/src/__tests__/FileTree.newFile.smoke.test.tsx
+++ b/src/__tests__/FileTree.newFile.smoke.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ActiveFileProvider from '../state/ActiveFileProvider';
+import FileTree from '../components/FileTree';
+import { hasPath } from '../lib/contentStore';
+
+describe('FileTree inline new file', () => {
+  it('creates a file under the selected directory', () => {
+    render(
+      <ActiveFileProvider>
+        <div role="tree">
+          <FileTree />
+        </div>
+      </ActiveFileProvider>,
+    );
+
+    // adjust selectors to your UI
+    const addBtn = screen.getByLabelText('add-file');
+    fireEvent.click(addBtn);
+
+    const input = screen.getByRole('textbox'); // the inline input
+    fireEvent.change(input, { target: { value: 'from-test.md' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(hasPath('app/from-test.md')).toBe(true);
+  });
+});

--- a/src/__tests__/contentStore.paths.test.ts
+++ b/src/__tests__/contentStore.paths.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  setContent,
+  deleteContent,
+  getPathsSnapshot,
+  subscribePaths,
+} from '../lib/contentStore';
+
+describe('contentStore path topology', () => {
+  it('emits only on add/remove (not on content edit)', () => {
+    const cb = vi.fn();
+    const unsub = subscribePaths(cb);
+
+    const p = 'app/test-new-file.txt';
+
+    const beforeLen = getPathsSnapshot().length;
+
+    setContent(p, ''); // ADD → emit
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(getPathsSnapshot().length).toBe(beforeLen + 1);
+
+    setContent(p, 'changed'); // EDIT → no emit
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    deleteContent(p); // REMOVE → emit
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(getPathsSnapshot().length).toBe(beforeLen);
+
+    unsub();
+  });
+
+  it('returns a stable array reference when nothing changed', () => {
+    const a = getPathsSnapshot();
+    const b = getPathsSnapshot();
+    expect(a).toBe(b); // referential equality
+  });
+});

--- a/src/__tests__/useFilesList.test.tsx
+++ b/src/__tests__/useFilesList.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useFilesList from '../hooks/useFilesList';
+import {
+  __resetStoreForTests,
+  setContent,
+  deleteContent,
+} from '../lib/contentStore';
+
+beforeEach(() => {
+  __resetStoreForTests({
+    clearLocalStorage: true,
+    files: [
+      { path: 'app/README.md', content: '# seed' },
+      { path: 'app/main.tsx', content: 'export {}' },
+    ],
+  });
+});
+
+describe('useFilesList', () => {
+  it('re-renders when a new file is added/removed', () => {
+    const { result } = renderHook(() => useFilesList());
+    const initial = result.current.length;
+
+    const p = 'app/xyz-new.md';
+
+    act(() => {
+      setContent(p, '');
+    });
+
+    expect(result.current.length).toBe(initial + 1);
+    expect(result.current).toContain(p);
+
+    act(() => {
+      deleteContent(p);
+    });
+
+    expect(result.current.length).toBe(initial);
+    expect(result.current).not.toContain(p);
+  });
+});

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -41,6 +41,11 @@ const FileTree = () => {
   );
 
   const {
+    openFile,
+    setTreeFocusPath,
+    toggleExpanded,
+    beginNewFileAt,
+  } = useFileActions();
   const { expandedPaths, treeFocusPath } = useFileState();
   const rowRefs = useRef(new Map<string, HTMLDivElement>());
 
@@ -92,9 +97,23 @@ const FileTree = () => {
 
   return (
     <div className="h-full border border-r bg-neutral-800">
-      <div className="mb-1 font-bold text-[0.82rem] text-neutral-300">
+      <div className="flex my-1 pl-1">
         <span className="mt-1 font-bold text-[0.82rem] text-neutral-300">
           {reactTutorialFiles.name.toUpperCase()}
+        </span>
+        <span className="grow" />
+        <span className="relative">
+          <button
+            className="peer rounded-md px-2 text-neutral-300 hover:bg-neutral-700 hover:cursor-pointer"
+            onClick={() => beginNewFileAt(treeFocusPath!)}
+            aria-label="add-file"
+          >
+            +
+          </button>
+          <span className="absolute -left-16 top-8 text-xs opacity-0 transition-opacity ease-in-out duration-200 peer-hover:opacity-100 bg-neutral-800 border border-neutral-400 text-neutral-300 px-2 py-1 rounded-md">
+            Add new file
+          </span>
+        </span>
       </div>
       <div
         role="tree"

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useFileState, useFileActions } from '../state/ActiveFileProvider';
+import useFilesList from '../hooks/useFilesList';
+import buildTree from '../lib/buildTree';
 import type { FileNode } from '../utils/types';
 import FileTreeNode from './FileTreeNode';
+import reactTutorialFiles from '../data/reactTutorialFiles';
 
 type FlatNode = {
   path: string;
@@ -30,14 +33,14 @@ const visibleNodes = (root: FileNode, expandedPaths: Set<string>) => {
   return out;
 };
 
-const FileTree = ({
-  projectName,
-  rootNode,
-}: {
-  projectName: string;
-  rootNode: FileNode;
-}) => {
-  const { openFile, setTreeFocusPath, toggleExpanded } = useFileActions();
+const FileTree = () => {
+  const paths = useFilesList();
+  const rootNode = useMemo(
+    () => buildTree(paths.map((p) => ({ path: p }))),
+    [paths],
+  );
+
+  const {
   const { expandedPaths, treeFocusPath } = useFileState();
   const rowRefs = useRef(new Map<string, HTMLDivElement>());
 
@@ -90,7 +93,8 @@ const FileTree = ({
   return (
     <div className="h-full border border-r bg-neutral-800">
       <div className="mb-1 font-bold text-[0.82rem] text-neutral-300">
-        {projectName.toUpperCase()}
+        <span className="mt-1 font-bold text-[0.82rem] text-neutral-300">
+          {reactTutorialFiles.name.toUpperCase()}
       </div>
       <div
         role="tree"

--- a/src/hooks/useFilesList.ts
+++ b/src/hooks/useFilesList.ts
@@ -1,0 +1,8 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import { subscribePaths, getPathsSnapshot } from '../lib/contentStore';
+
+export default function useFilesList(): string[] {
+  const subscribe = useCallback(subscribePaths, []);
+  const getSnap = useCallback(getPathsSnapshot, []);
+  return useSyncExternalStore(subscribe, getSnap, getSnap);
+}

--- a/src/lib/buildTree.ts
+++ b/src/lib/buildTree.ts
@@ -5,7 +5,11 @@ const buildTree = (files: { path: string }[]): FileNode => {
 
   // build file tree from flat file paths
   for (const file of files) {
-    const pathArray = file.path.split('/').filter(Boolean);
+    const isExplicitDir = file.path.endsWith('/');
+    const normalizedPath = isExplicitDir
+      ? file.path.replace(/\/+$/, '')
+      : file.path;
+    const pathArray = normalizedPath.split('/').filter(Boolean);
     let currentNode = root;
 
     pathArray.forEach((segment, idx) => {
@@ -23,7 +27,9 @@ const buildTree = (files: { path: string }[]): FileNode => {
       currentNode = nextNodeInPath;
     });
 
-    if (currentNode.children && currentNode.children.length === 0) {
+    if (isExplicitDir) {
+      if (!currentNode.children) currentNode.children = [];
+    } else if (currentNode.children && currentNode.children.length === 0) {
       delete currentNode.children;
     }
   }

--- a/src/lib/contentStore.ts
+++ b/src/lib/contentStore.ts
@@ -2,13 +2,219 @@ import files from '../data/reactTutorialFiles';
 import normalizePath from '../utils/normalizePath';
 
 const byPath = new Map<string, string>();
+export const folders = new Set<string>();
+const listeners = new Set<() => void>();
 
 for (const f of files.files) {
   byPath.set(normalizePath(f.path), f.content ?? '');
 }
 
+let pathsSnapshot: string[] = [];
+const recomputePathsSnapshot = () => {
+  pathsSnapshot = [
+    ...Array.from(folders).map((f) => (f.endsWith('/') ? f : f + '/')),
+    ...Array.from(byPath.keys()),
+  ].sort();
+};
+
+function emit() {
+  listeners.forEach((fn) => fn());
+}
+
+const isUnder = (p: string, base: string) =>
+  p === base || p.startsWith(base + '/');
+
 export const getContent = (p: string) => byPath.get(normalizePath(p)) ?? '';
 
 export const setContent = (p: string, text: string) => {
-  byPath.set(normalizePath(p), text);
+  const norm = normalizePath(p);
+  const isNew = !byPath.has(norm);
+  byPath.set(norm, text);
+  if (isNew) {
+    recomputePathsSnapshot();
+    emit();
+  }
+  schedulePersist();
 };
+
+export const deleteContent = (p: string) => {
+  const norm = normalizePath(p);
+  if (byPath.delete(norm)) {
+    recomputePathsSnapshot();
+    emit();
+  }
+  schedulePersist();
+};
+
+export const renamePath = (oldPathRaw: string, newPathRaw: string) => {
+  const newPath = normalizePath(newPathRaw);
+  const oldPath = normalizePath(oldPathRaw);
+  if (byPath.has(newPath) || !byPath.has(oldPath)) return false;
+  const content = byPath.get(oldPath) ?? '';
+  byPath.delete(oldPath);
+  byPath.set(newPath, content);
+  recomputePathsSnapshot();
+  emit();
+  schedulePersist();
+  return true;
+};
+
+export const getAllPaths = () => Array.from(byPath.keys());
+
+export const subscribePaths = (cb: () => void) => {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+};
+
+export const hasPath = (p: string) => byPath.has(normalizePath(p));
+
+export const getPathsSnapshot = () => pathsSnapshot;
+
+export const addFolder = (dirPath: string) => {
+  const dir = normalizePath(dirPath);
+  if (!folders.has(dir)) {
+    folders.add(dir);
+    recomputePathsSnapshot();
+    emit();
+  }
+  schedulePersist();
+};
+
+export const deleteTree = (baseRaw: string) => {
+  const base = normalizePath(baseRaw);
+  let changed = false;
+
+  // delete the file itself (if base is a file)
+  if (byPath.delete(base)) changed = true;
+
+  // delete all files under base as a folder
+  for (const p of Array.from(byPath.keys())) {
+    if (isUnder(p, base) && p !== base) {
+      byPath.delete(p);
+      changed = true;
+    }
+  }
+
+  // delete the folder entry and any subfolders
+  for (const f of Array.from(folders)) {
+    if (isUnder(f, base)) {
+      folders.delete(f);
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    recomputePathsSnapshot();
+    emit();
+    schedulePersist();
+  }
+};
+
+export const renameFolder = (oldDirRaw: string, newDirRaw: string) => {
+  const oldDir = normalizePath(oldDirRaw);
+  const newDir = normalizePath(newDirRaw);
+
+  if (!folders.has(oldDir) || folders.has(newDir)) return false;
+  for (const p of Array.from(byPath.keys())) {
+    if (isUnder(p, oldDir)) {
+      const moved = newDir + p.slice(oldDir.length);
+      byPath.set(moved, byPath.get(p)!);
+      byPath.delete(p);
+    }
+  }
+
+  for (const f of Array.from(folders)) {
+    if (isUnder(f, oldDir)) {
+      folders.delete(f);
+      folders.add(newDir + f.slice(oldDir.length));
+    }
+  }
+
+  folders.delete(oldDir);
+  folders.add(newDir);
+
+  recomputePathsSnapshot();
+  emit();
+  schedulePersist();
+  return true;
+};
+
+let timer: number | null = null;
+const schedulePersist = () => {
+  if (typeof window === 'undefined') return;
+  if (timer) window.clearTimeout(timer);
+  timer = window.setTimeout(() => {
+    const data = {
+      files: Object.fromEntries(byPath),
+      folders: Array.from(folders ?? []),
+    };
+    localStorage.setItem('fv:files:v1', JSON.stringify(data));
+  }, 200);
+};
+
+let initialized = false;
+
+(function initStore() {
+  if (initialized) return;
+  initialized = true;
+
+  try {
+    if (typeof window !== 'undefined') {
+      const raw = localStorage.getItem('fv:files:v1');
+      if (raw) {
+        const { files, folders: fs } = JSON.parse(raw);
+        if (files) {
+          for (const [p, txt] of Object.entries(files)) {
+            byPath.set(normalizePath(p), String(txt));
+          }
+        }
+        if (Array.isArray(fs)) {
+          fs.forEach((f) => folders.add(`${normalizePath(f)}/`));
+        }
+      } else {
+        // seed demo data if no LS payload
+        for (const f of files.files) {
+          byPath.set(normalizePath(f.path), f.content ?? '');
+        }
+      }
+    } else {
+      // SSR/test environment: seed demo data
+      for (const f of files.files) {
+        byPath.set(normalizePath(f.path), f.content ?? '');
+      }
+    }
+  } catch {
+    // on parse error, fall back to seed
+    for (const f of files.files) {
+      byPath.set(normalizePath(f.path), f.content ?? '');
+    }
+  } finally {
+    recomputePathsSnapshot(); // exactly once after hydrate/seed
+  }
+})();
+
+export function __resetStoreForTests(opts?: {
+  files?: Array<{ path: string; content?: string }>;
+  folders?: string[];
+  clearLocalStorage?: boolean;
+}) {
+  if (opts?.clearLocalStorage && typeof window !== 'undefined') {
+    try {
+      localStorage.clear();
+    } catch {}
+  }
+  byPath.clear();
+  folders.clear();
+
+  if (opts?.folders) {
+    for (const f of opts.folders)
+      folders.add(normalizePath(f).replace(/\/+$/, ''));
+  }
+  if (opts?.files) {
+    for (const f of opts.files)
+      byPath.set(normalizePath(f.path), f.content ?? '');
+  }
+
+  recomputePathsSnapshot();
+  emit();
+}


### PR DESCRIPTION
**What & Why**
Enables file creation in the fileTree by clicking the new file control

**Changes**

- `FileTreeNode`: add new inline input component that appears when `newDraft !== null`
- `FileTree`: add new button that calls `startNewFileAt`, setting `newDraft` with a value and causing the inline component to render
- `ActiveFileProvider`: functions to interact with contentStore and create new files without re-render loops using refs
- Tests using the new add file button and contentStore modifiers

**Test Plan**

- [ ] Click the '+' button in filetree -> give new file a name; should see fileIcon that matches extension and open new file onBlur

**Risk / Rollback**
Low / revert FileTree, FileTreeNode, ActiveFileProvider if needed
