### PR TITLE
refactor(AFP): solid rename folder/file + deleteTree expansion/focus

### DIFF
--- a/src/__tests__/components/FileTree.newFile.smoke.test.tsx
+++ b/src/__tests__/components/FileTree.newFile.smoke.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import ActiveFileProvider from '../state/ActiveFileProvider';
-import FileTree from '../components/FileTree';
-import { hasPath } from '../lib/contentStore';
+import ActiveFileProvider from '../../state/ActiveFileProvider';
+import FileTree from '../../components/FileTree';
+import { hasPath } from '../../lib/contentStore';
 
 describe('FileTree inline new file', () => {
   it('creates a file under the selected directory', () => {
@@ -14,11 +14,10 @@ describe('FileTree inline new file', () => {
       </ActiveFileProvider>,
     );
 
-    // adjust selectors to your UI
     const addBtn = screen.getByLabelText('add-file');
     fireEvent.click(addBtn);
 
-    const input = screen.getByRole('textbox'); // the inline input
+    const input = screen.getByRole('textbox');
     fireEvent.change(input, { target: { value: 'from-test.md' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 

--- a/src/__tests__/state/ActiveFileProvider.core.test.tsx
+++ b/src/__tests__/state/ActiveFileProvider.core.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+import { renderWithProvider, Probe } from '../../test/utils';
+
+describe('ActiveFileProvider core functions', () => {
+  it('opens and closes files, updates activePath', async () => {
+    let api: any;
+    renderWithProvider(<Probe onReady={(a) => (api = a)} />);
+    await act(async () => {
+      api.actions.openFile('app/README.md');
+      api.actions.openFile('app/src/main.tsx');
+      api.actions.closeFile('app/README.md');
+    });
+    await waitFor(() => {
+      expect(api.getState().activePath).toBe('app/src/main.tsx');
+    });
+  });
+
+  it('setIsDirty toggles and saveFile clears dirty', async () => {
+    let api: any;
+    renderWithProvider(<Probe onReady={(a) => (api = a)} />);
+    await act(async () => {
+      api.actions.openFile('app/src/main.tsx');
+      api.actions.setIsDirty('app/src/main.tsx', true);
+    });
+    await waitFor(() => {
+      expect(api.getState().dirtyByPath.get('app/src/main.tsx')).toBe(true);
+    });
+    await act(async () => {
+      api.actions.saveFile('app/src/main.tsx');
+    });
+    await waitFor(() => {
+      expect(api.getState().dirtyByPath.get('app/src/main.tsx')).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/state/ActiveFileProvider.flows.test.tsx
+++ b/src/__tests__/state/ActiveFileProvider.flows.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  act,
+  waitFor,
+  render,
+  fireEvent,
+  screen,
+} from '@testing-library/react';
+import { Probe, renderWithProvider } from '../../test/utils';
+import { __resetStoreForTests } from '../../lib/contentStore';
+import * as store from '../../lib/contentStore';
+import { FileTree } from '../../components';
+import ActiveFileProvider from '../../state/ActiveFileProvider';
+
+describe('test complex ActiveFileProvider flows', () => {
+  beforeEach(() => {
+    try {
+      localStorage.clear();
+    } catch {}
+    __resetStoreForTests({
+      clearLocalStorage: true,
+      files: [
+        { path: 'app/README.md', content: '# readme' },
+        { path: 'app/src/main.tsx', content: 'export {}' }, // <-- seed it
+      ],
+      folders: ['app', 'app/src'],
+    });
+  });
+
+  it('deletePathAt prompts when any descendant is dirty', async () => {
+    let api: any;
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    renderWithProvider(<Probe onReady={(a) => (api = a)} />);
+
+    await act(async () => {
+      api.actions.openFile('app/src/main.tsx');
+    });
+    await act(async () => {
+      api.actions.setIsDirty('app/src/main.tsx', true);
+    });
+    await waitFor(() => {
+      expect(api.getState().dirtyByPath.get('app/src/main.tsx')).toBe(true);
+    });
+
+    await act(async () => {
+      api.actions.deletePathAt('app');
+    });
+    await waitFor(() => {
+      expect(confirm).toHaveBeenCalledTimes(1);
+    });
+
+    confirm.mockRestore();
+  });
+
+  it('renames a file and remaps tabs/active/dirty', async () => {
+    let api: any;
+    renderWithProvider(<Probe onReady={(a) => (api = a)} />);
+
+    const from = 'app/src/main.tsx';
+    const to = 'app/src/main.new.tsx';
+
+    await act(async () => {
+      api.actions.openFile(from);
+    });
+    await act(async () => {
+      api.actions.setIsDirty(from, true);
+    });
+    await waitFor(async () => {
+      expect(api.getState().dirtyByPath.get(from)).toBe(true);
+    });
+
+    await act(async () => {
+      api.actions.beginRenameAt(from);
+    });
+    await act(async () => {
+      api.actions.setRenameName('main.new.tsx');
+    });
+    await act(async () => {
+      api.actions.confirmRename();
+    });
+
+    await waitFor(async () => {
+      expect(api.getState().activePath).toBe(to);
+      expect(api.getState().openPaths).toContain(to);
+      expect(api.getState().openPaths).not.toContain(from);
+      expect(api.getState().dirtyByPath.get(to)).toBe(true);
+      expect(api.getState().dirtyByPath.has(from)).toBe(false);
+    });
+  });
+
+  it('renames a folder and moves descendants', async () => {
+    let api: any;
+    renderWithProvider(<Probe onReady={(a) => (api = a)} />);
+
+    const spy = vi.spyOn(store, 'renameFolder');
+
+    const oldDir = 'app/src';
+    const newDirName = 'src-renamed';
+    const movedFile = 'app/src/main.tsx';
+    const expected = 'app/src-renamed/main.tsx';
+
+    await act(async () => {
+      api.actions.openFile(movedFile);
+    });
+    await act(async () => {
+      api.actions.beginRenameAt(oldDir);
+    });
+    await act(async () => {
+      api.actions.setRenameName(newDirName);
+    });
+    await act(async () => {
+      api.actions.confirmRename();
+    });
+
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith('app/src', 'app/src-renamed'),
+    );
+
+    await waitFor(() => {
+      expect(api.getState().openPaths).toContain(expected);
+    });
+  });
+
+  it('registers beforeunload when any dirty, removes when clean', async () => {
+    let api: any;
+    renderWithProvider(<Probe onReady={(a) => (api = a)} />);
+    const add = vi.spyOn(window, 'addEventListener');
+    const rem = vi.spyOn(window, 'removeEventListener');
+
+    await act(async () => {
+      api.actions.setIsDirty('app/README.md', true);
+    });
+    await waitFor(() => {
+      expect(api.getState().dirtyByPath.get('app/README.md')).toBe(true);
+      expect(add).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+    });
+
+    await act(async () => {
+      api.actions.setIsDirty('app/README.md', false);
+    });
+    await waitFor(() => {
+      expect(rem).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+    });
+  });
+
+  it('saveFile clears dirty and persists (debounced)', async () => {
+    let api: any;
+    renderWithProvider(<Probe onReady={(a) => (api = a)} />);
+    const p = 'app/src/main.tsx';
+
+    await act(async () => {
+      api.actions.setIsDirty(p, true);
+    });
+    await waitFor(() => {
+      expect(api.getState().dirtyByPath.get(p)).toBe(true);
+    });
+
+    vi.useFakeTimers();
+    await act(async () => {
+      api.actions.saveFile(p);
+    });
+
+    expect(api.getState().dirtyByPath.get(p)).toBe(false);
+
+    vi.runAllTimers();
+    vi.useRealTimers();
+
+    const raw = localStorage.getItem('fv:files:v1');
+    expect(raw).toContain(p);
+  });
+
+  it('context menu opens and New File starts draft', () => {
+    render(
+      <ActiveFileProvider>
+        <FileTree />
+      </ActiveFileProvider>,
+    );
+    const row = screen.getAllByRole('treeitem')[0];
+    fireEvent.contextMenu(row);
+
+    const newFile = screen.getByRole('menuitem', { name: /new file/i });
+    fireEvent.click(newFile);
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/state/ActiveFileProvider.newFile.test.tsx
+++ b/src/__tests__/state/ActiveFileProvider.newFile.test.tsx
@@ -1,12 +1,11 @@
-// src/__tests__/ActiveFileProvider.newFile.test.tsx
 import { describe, it, expect } from 'vitest';
 import { useEffect } from 'react';
 import { render, screen } from '@testing-library/react';
 import ActiveFileProvider, {
   useFileActions,
   useFileState,
-} from '../state/ActiveFileProvider';
-import { getContent, hasPath } from '../lib/contentStore';
+} from '../../state/ActiveFileProvider';
+import { getContent, hasPath } from '../../lib/contentStore';
 
 function DriveNewFile({ dir, name }: { dir: string; name: string }) {
   const { beginNewFileAt, setNewFileName, confirmNewFile } = useFileActions();
@@ -37,7 +36,7 @@ describe('ActiveFileProvider new file', () => {
     const expected = 'app/newfile.test.md';
 
     expect(hasPath(expected)).toBe(true);
-    expect(getContent(expected)).toBe(''); // committed empty content
+    expect(getContent(expected)).toBe('');
 
     expect(screen.getByTestId('active').textContent).toBe(expected);
     expect(screen.getByTestId('open').textContent).toContain(expected);

--- a/src/state/ActiveFileProvider.tsx
+++ b/src/state/ActiveFileProvider.tsx
@@ -464,6 +464,18 @@ const ActiveFileProvider = ({
           return next;
         });
 
+        setExpandedPaths((prev) => {
+          const next = new Set(prev);
+          for (const p of Array.from(next)) {
+            if (isUnder(p, pNorm)) next.delete(p);
+          }
+          return next;
+        });
+
+        setTreeFocusPath((curr) =>
+          curr && isUnder(curr, pNorm) ? null : curr,
+        );
+
         deleteTree(pNorm);
       },
 


### PR DESCRIPTION
**What & Why**
Reworks confirmRenameImpl to treat directories explicitly and remap all dependent state (dirty flags, open tabs, expanded nodes, focus). Ensures deleteTree updates expandedPaths and tree focus cleanly.

**Test Plan**

- [ ] Rename folder updates activePath/openPaths/expandedPaths/treeFocus
- [ ] deleteTree removes descendants and focus doesn't dangle

**Risk / Rollback**
Low / revert ActiveFileProvider if needed
