### PR TITLE
test(Tabs): behavior, nav, a11y, move old

### DIFF
--- a/src/__tests__/components/Tabs.behavior.test.tsx
+++ b/src/__tests__/components/Tabs.behavior.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ActiveFileProvider from '../../state/ActiveFileProvider';
+import Tabs from '../../components/Tabs';
+import Editor from '../../components/Editor';
+import { Probe } from '../../test/utils';
+import { vi, describe, it, expect } from 'vitest';
+
+describe('Tabs behavior', () => {
+  it('close activates nearest-right else left; supports keyboard close', async () => {
+    const user = userEvent.setup();
+
+    let api: any;
+    render(
+      <ActiveFileProvider initial={{ activePath: null, openPaths: [] }}>
+        <Probe onReady={(a) => (api = a)} />
+        <Tabs />
+        <Editor />
+      </ActiveFileProvider>,
+    );
+
+    ['a.ts', 'b.ts', 'c.ts'].forEach((p) => api.actions.openFile(p));
+    api.actions.setActivePath('b.ts');
+
+    const bTab = await screen.findByRole('tab', { name: /b\.ts/ });
+    bTab.focus();
+
+    await user.keyboard('{Delete}');
+    expect(screen.getByRole('tab', { selected: true })).toHaveTextContent(
+      'c.ts',
+    );
+
+    const activeTab = screen.getByRole('tab', {
+      selected: true,
+    }) as HTMLElement;
+    activeTab.focus();
+
+    const chord = navigator.platform.includes('Mac')
+      ? { key: 'w', metaKey: true, bubbles: true }
+      : { key: 'w', ctrlKey: true, bubbles: true };
+
+    fireEvent.keyDown(activeTab, chord);
+
+    expect(screen.getByRole('tab', { selected: true })).toHaveTextContent(
+      'a.ts',
+    );
+  });
+
+  it('requests a frame to scroll when active changes', async () => {
+    const rafSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: any) => {
+        cb(0);
+        return 1 as any;
+      });
+
+    let api: any;
+    render(
+      <ActiveFileProvider>
+        <Probe onReady={(a) => (api = a)} />
+        <Tabs />
+        <Editor />
+      </ActiveFileProvider>,
+    );
+
+    const paths = ['a.ts', 'b.ts', 'c.ts'];
+    paths.forEach((p) => api.actions.openFile(p));
+
+    await screen.findByRole('tab', { name: /a\.ts/ });
+    api.actions.setActivePath('a.ts');
+    api.actions.setActivePath('c.ts');
+
+    await waitFor(() => expect(rafSpy).toHaveBeenCalled());
+    rafSpy.mockRestore();
+  });
+});

--- a/src/__tests__/components/Tabs.nav.test.tsx
+++ b/src/__tests__/components/Tabs.nav.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ActiveFileProvider from '../../state/ActiveFileProvider';
+import Tabs from '../../components/Tabs';
+import Editor from '../../components/Editor';
+import { Probe } from '../../test/utils';
+
+describe('Tests tabs key navigation in component', () => {
+  function key(el: Element, init: KeyboardEventInit) {
+    el.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, ...init }));
+  }
+
+  it('tablist arrow nav + Home/End + Enter select', async () => {
+    let api: any;
+
+    render(
+      <ActiveFileProvider initial={{ activePath: null, openPaths: [] }}>
+        <Probe onReady={(a) => (api = a)} />
+        <Tabs />
+        <Editor />
+      </ActiveFileProvider>,
+    );
+
+    ['a.ts', 'b.ts', 'c.ts'].forEach((p) => api.actions.openFile(p));
+    api.actions.setActivePath('b.ts');
+
+    const tablist = screen.getByRole('tablist');
+    const bTab = await screen.findByRole('tab', {
+      name: /b\.ts/,
+      selected: true,
+    });
+    (bTab as HTMLElement).focus();
+
+    key(tablist, { key: 'ArrowRight' });
+
+    const cTab = screen.getByRole('tab', { name: /c\.ts/ });
+    fireEvent.keyDown(cTab, { key: 'Enter', bubbles: true });
+
+    expect(screen.getByRole('tab', { selected: true })).toHaveTextContent(
+      'c.ts',
+    );
+
+    key(tablist, { key: 'Home' });
+    const aTab = screen.getByRole('tab', { name: /a\.ts/ });
+    fireEvent.keyDown(aTab, { key: ' ', bubbles: true });
+
+    expect(screen.getByRole('tab', { selected: true })).toHaveTextContent(
+      'a.ts',
+    );
+
+    key(tablist, { key: 'End' });
+    expect(screen.getByRole('tab', { name: /c\.ts/ })).toBeInTheDocument();
+  });
+
+  it('closes a tab on middle-click', async () => {
+    let api: any;
+    render(
+      <ActiveFileProvider initial={{ activePath: null, openPaths: [] }}>
+        <Probe onReady={(a) => (api = a)} />
+        <Tabs />
+        <Editor />
+      </ActiveFileProvider>,
+    );
+
+    ['a.ts', 'b.ts', 'c.ts'].forEach((p) => api.actions.openFile(p));
+    api.actions.setActivePath('b.ts');
+
+    const bTab = await screen.findByRole('tab', { name: /b\.ts/ });
+
+    fireEvent(
+      bTab,
+      new MouseEvent('auxclick', {
+        button: 1,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByRole('tab', { name: /b\.ts/ })).toBeNull(),
+    );
+  });
+});

--- a/src/__tests__/components/a11y/tabs.a11y.test.tsx
+++ b/src/__tests__/components/a11y/tabs.a11y.test.tsx
@@ -1,9 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
-import Tabs from '../components/Tabs';
-// import { useState } from 'react';
-import ActiveFileProvider from '../state/ActiveFileProvider';
+import Tabs from '../../../components/Tabs';
+import ActiveFileProvider from '../../../state/ActiveFileProvider';
 
 describe('Tabs a11y semantics', () => {
   function TabsHarness({

--- a/src/__tests__/components/tabs.test.tsx
+++ b/src/__tests__/components/tabs.test.tsx
@@ -1,10 +1,10 @@
 import { describe, expect, test, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import user from '@testing-library/user-event';
-import Tabs from '../components/Tabs';
-import ActiveFileProvider from '../state/ActiveFileProvider';
-import { nextFrame } from '../test/utils';
-import { getAllTabs, oneTabbable } from '../test/utils';
+import Tabs from '../../components/Tabs';
+import ActiveFileProvider from '../../state/ActiveFileProvider';
+import { nextFrame } from '../../test/utils';
+import { getAllTabs, oneTabbable } from '../../test/utils';
 
 function TabsHarness({
   open = [
@@ -44,14 +44,12 @@ describe('Tabs - roving and activation', () => {
     (oneTabbable()[0] as HTMLElement).focus();
     expect(oneTabbable()[0]).toHaveFocus();
 
-    // ArrowRight moves focus only (not selection)
     await k('{ArrowRight}');
     const tabsAfter = getAllTabs();
     expect(oneTabbable()).toHaveLength(1);
     expect(
       tabsAfter.some((t) => t.getAttribute('aria-selected') === 'true'),
     ).toBe(true);
-    // Focus is on a tab, but aria-selected stays with the previously active one
     const focused = document.activeElement as HTMLElement;
     expect(focused).toHaveAttribute('role', 'tab');
   });
@@ -72,14 +70,14 @@ describe('Tabs - roving and activation', () => {
     render(<TabsHarness />);
     (oneTabbable()[0] as HTMLElement).focus();
 
-    await k('{ArrowRight}'); // move focus to a different tab
+    await k('{ArrowRight}');
     const focused = document.activeElement as HTMLElement;
     expect(focused).toHaveAttribute('role', 'tab');
     expect(focused).toHaveAttribute('aria-selected', 'false');
 
-    await k('{Enter}'); // activate
+    await k('{Enter}');
     expect(focused).toHaveAttribute('aria-selected', 'true');
-    expect(focused).toHaveFocus(); // focus stays put
+    expect(focused).toHaveFocus();
   });
 
   test('Delete closes the focused tab and moves focus to its neighbor', async () => {
@@ -93,9 +91,7 @@ describe('Tabs - roving and activation', () => {
 
     await k('{Delete}');
     const tabs1 = getAllTabs();
-    // One fewer tab
     expect(tabs1.length).toBe(tabs0.length - 1);
-    // Focus moved to neighbor (same index now points at the next one)
     const neighbor = tabs1[Math.min(beforeIdx, tabs1.length - 1)];
     expect(neighbor).toHaveFocus();
   });
@@ -115,17 +111,14 @@ describe('Tabs - roving and activation', () => {
     render(<TabsHarness />);
     const all = getAllTabs();
 
-    // spy on scrollIntoView for a far tab
     const far = all.at(-1)! as HTMLElement;
     const spy = vi
       .spyOn(far, 'scrollIntoView' as any)
       .mockImplementation(() => {});
 
-    // move focus to far tab then activate with Enter
     far.focus();
     await k('{Enter}');
 
-    // effect runs in rAF; give it a tick
     await new Promise((r) => requestAnimationFrame(() => r(undefined)));
     expect(spy).toHaveBeenCalled();
 


### PR DESCRIPTION
**What & Why**
Adds keyboard + middle-click coverage reflecting actual handlers, uses RAF spy to assert scroll scheduling

**Test Plan**

- [ ] Behavior mirrors manual interaction in the app
- [ ] No dependency on DOM geometry
- [ ] Stable across CI
